### PR TITLE
Clarifying cURL link of task 25 with REPLACE_WITH_USER_ID parameter to replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,11 +516,13 @@ Scroll down below the Call operation button. You should see a **200 OK** and a *
 
 
 It is now time to test our API from the command line.
-From the previous cURL screen, Copy the cURL example from the left side into your text editor window replacing REPLACE_WITH_CLIENT_ID and REPLACE_WITH_CLIENT_SECRET with your client id and your client secret saved from the prior step
+From the previous cURL screen, copy the cURL example from the left side into your text editor window replacing REPLACE_WITH_CLIENT_ID and REPLACE_WITH_CLIENT_SECRET with your client id and your client secret saved from the prior step.
+
+Or copy the link below and replacing REPLACE_WITH_USER_ID with your user id (that is your login email without the `@` and `.` . For example `philmetal@mail.com` user id is `philmetalmailcom`), and replacing REPLACE_WITH_CLIENT_ID and REPLACE_WITH_CLIENT_SECRET with your client id and your client secret. 
 
 ```
 curl --request GET \
-  --url 'https://api.eu.apiconnect.ibmcloud.com/philmetalmailcom-dev/sb/loanmgt/resources/loans/v1/extQuote?loanAmount=10000&annualInterestRate=1.1&termInMonths=36&delay=10&msgLength=725' \
+  --url 'https://api.eu.apiconnect.ibmcloud.com/REPLACE_WITH_USER_ID-dev/sb/loanmgt/resources/loans/v1/extQuote?loanAmount=10000&annualInterestRate=1.1&termInMonths=36&delay=10&msgLength=725' \
   --header 'accept: application/json' \
   --header 'x-ibm-client-id: REPLACE_WITH_CLIENT_ID' \
   --header 'x-ibm-client-secret: REPLACE_WITH_CLIENT_SECRET'


### PR DESCRIPTION
Hello, I attended the APIdays workshop and managed to follow your tutorial to the last task.

I noticed that the curl request documented at task 25 has one parameter that still needs to be replace, but that’s not specified in the doc. I called the parameter user id for no better name came to mind.

Copying this link to the terminal and replacing only REPLACE_WITH_CLIENT_ID and REPLACE_WITH_CLIENT_SECRET will return a 401 unauthorised error.

Having wrote other documentation, I think that many participant will take the easy road of just copying the curl request from the doc, and not understanding the posted back error because the user id is hidden in the middle of the URL.

Hope that helps.